### PR TITLE
docker: Add initial Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:6-onbuild
+
+RUN echo "PORT=3030\nDATA_API=stay-woke-central.mattstauffer.co\nDATA_API_PORT=80\nDEBUG=app" > .env
+
+EXPOSE 3030
+
+ENTRYPOINT ["npm", "run"]
+


### PR DESCRIPTION
This adds a Dockerfile that builds the application.

- Exposes port 3030
- Uses the default .env settings for everything else
